### PR TITLE
bug: :bug: [#22] Partial fix in table header. 

### DIFF
--- a/woo-variations-table.php
+++ b/woo-variations-table.php
@@ -304,7 +304,7 @@ function woo_variations_table_print_table()
         $variation_attributes = $product->get_variation_attributes();
         $attrs = array();
         foreach ($variation_attributes as $key => $name) {
-            $correctkey = wc_sanitize_taxonomy_name(stripslashes($key));
+            $correctkey = strtolower(urlencode(wc_sanitize_taxonomy_name(stripslashes($key))));
             $options = array();
             for ($i = 0; count($name) > $i; $i++) {
                 $terms = array_values($name);


### PR DESCRIPTION
Resolve some forum report regarding encoding in column headers. 
https://wordpress.org/support/topic/problem-with-non-latin-product-attribute/
Content encoding problem reported in #22 is not fixed within this commit.